### PR TITLE
Redirect /wp-admin, /wp-content, and /wp-json

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "routes": [
+    {
+      "src": "/wp-admin/(.*)",
+      "status": 301,
+      "headers": { "Location": "https://wp.stanforddaily.com/wp-admin/$1" }
+    },
+    {
+      "src": "/wp-content/(.*)",
+      "status": 301,
+      "headers": { "Location": "https://wp.stanforddaily.com/wp-content/$1" }
+    },
+    {
+      "src": "/wp-json/(.*)",
+      "status": 301,
+      "headers": { "Location": "https://wp.stanforddaily.com/wp-json/$1" }
+    }
+  ]
+}

--- a/now.json
+++ b/now.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "scope": "tsd",
   "routes": [
     {
       "src": "/wp-admin/(.*)",


### PR DESCRIPTION
Redirect https://www.stanforddaily.com/wp-admin, https://www.stanforddaily.com/wp-content, and https://www.stanforddaily.com/wp-json to corresponding pages on https://wp.stanforddaily.com.